### PR TITLE
Update Go to version 1.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ The MIT License (MIT)
 
 # Changelog
 
+## 1.3.2
+
+- Update Go to 1.4.2
+
 ## 1.3.1
 
 - Update Go to 1.4.1

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Box that runs Go 1.4.1
 
 # What's new
 
-- Update Go to 1.4.1
+- Update Go to 1.4.2
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # golang box
 
-Box that runs Go 1.4.1
+Box that runs latest stable version of Go.
 
 [![wercker status](https://app.wercker.com/status/cb0eb61be1b3e5bb4bc2c475d2c3e7c8/m "wercker status")](https://app.wercker.com/project/bykey/cb0eb61be1b3e5bb4bc2c475d2c3e7c8)
 

--- a/wercker-box.yml
+++ b/wercker-box.yml
@@ -1,5 +1,5 @@
 name: golang
-version: 1.3.1
+version: 1.3.2
 inherits: wercker/ubuntu12.04-webessentials@1.0.4
 type : main
 platform : ubuntu@12.04

--- a/wercker-box.yml
+++ b/wercker-box.yml
@@ -8,12 +8,12 @@ keywords:
   - golang
   - go
 packages :
-  - golang@1.4.1
+  - golang@1.4.2
   - git
   - mercurial
   - bzr
 script : |
-  version="1.4.1"
+  version="1.4.2"
 
   sudo apt-get update
   sudo apt-get install bzr


### PR DESCRIPTION
This pull requests updates the following things:

* Update Go from version 1.4.1 to the latest stable version 1.4.2.
* Make box description explicit about the goal of this box.

As a reference, this is what is fixed in Go 1.4.2:

> go1.4.2 (released 2015/02/17) includes bug fixes to the go command, the compiler and linker, and the runtime, syscall, reflect, and math/big packages. See the Go 1.4.2 milestone on our issue tracker for details.